### PR TITLE
Disable auditd service to allow Rapid7 agent to run properly

### DIFF
--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -334,6 +334,11 @@ sudo  /tmp/lessonly/agent_installer.sh install --token us:$RAPID7_TOKEN
 # https://docs.rapid7.com/insight-agent/virtualization/
 sudo rm -rf /opt/rapid7/ir_agent/components/bootstrap/common/bootstrap.cfg
 
+# Disable auditd to allow Rapid7 Agent to work properly
+service auditd stop
+sudo systemctl disable auditd
+chkconfig auditd off
+
 ##############################
 ### CLAMAV
 #############################


### PR DESCRIPTION
# Description

[see sc-84112](https://app.shortcut.com/lessonly/story/84112)


Instructions from Rapid7 customer success manager
```
If the auditd service is required to be enabled then the following documentation is how to configure compatibility mode: https://docs.rapid7.com/insight-agent/auditd-compatibility-mode-for-linux-assets/
 
Although this is a native service to linux. You can check whether the auditd service is on the asset by running command: service auditd status


If for some reason it returns nothing / service not found you can run another command to install it depending on the type of Linux, examples below:
Red Hat 7: yum install audit
Ubuntu: sudo apt-get install auditd


If you do not need to run auditd in compatibility and you can just disable auditd, these are the steps of commands I received from support:
1) service auditd status
2) service auditd stop
3) sudo systemctl disable auditd
4) chkconfig auditd off
These steps will check the current status, stop auditd, disable it and prevent re-enable if a reboot occurs.
```
