### PR TITLE
Add subnet_id as env var input

### DIFF
--- a/eks-worker-al2.json
+++ b/eks-worker-al2.json
@@ -36,7 +36,8 @@
     "additional_yum_repos": "",
     "sonobuoy_e2e_registry": "",
     "ami_regions": "",
-    "rapid7_token": "{{env `RAPID7_TOKEN`}}"
+    "rapid7_token": "{{env `RAPID7_TOKEN`}}",
+    "subnet_id": "{{env `SUBNET_ID`}}"
   },
   "builders": [
     {


### PR DESCRIPTION
# Description

Adding subnet_id as an environment variable input to allow creation of the EC2 instance in a non-default vpc/subnet.

Note that the [packer documentation](https://www.packer.io/plugins/builders/amazon/ebs#vpc_id) states that it will try to pull the vpc_id if a subnet_id is given. 
Testing this first, but we may need to add a vpc_id env var if this doesn't work.