### PR TITLE
Updated runc to use the latest patch version.

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -23,7 +23,7 @@
     "pause_container_version": "3.5",
     "pull_cni_from_github": "true",
     "remote_folder": "",
-    "runc_version": "1.1.7-2.amzn2",
+    "runc_version": "1.1.*",
     "security_group_id": "",
     "sonobuoy_e2e_registry": "",
     "source_ami_filter_name": "amzn2-ami-minimal-hvm-*",


### PR DESCRIPTION
Changes:
- Pull in the latest `1.1.*` version of `runc` to avoid rebuilding AMI multiple times for CVEs.

Similar change was made in the upstream (avoiding pulling it since it has other changes):
- https://github.com/awslabs/amazon-eks-ami/commit/0ff39d48a91aa84f8fc3c76a5e06cc71b36ca347