### PR TITLE
Upgrade to containerd to patch CVEs.

### DIFF
--- a/eks-worker-al2-variables.json
+++ b/eks-worker-al2-variables.json
@@ -13,7 +13,7 @@
     "binary_bucket_region": "us-west-2",
     "cache_container_images": "false",
     "cni_plugin_version": "v0.8.6",
-    "containerd_version": "1.6.*",
+    "containerd_version": "1.7.*",
     "creator": "{{env `USER`}}",
     "docker_version": "20.10.23-1.amzn2.0.1",
     "encrypted": "true",


### PR DESCRIPTION
We need to be on `1.7.x` to patch the following CVEs according to the scans:
- CVE-2022-41721
- CVE-2023-3978

[Learning-Vulnerabilities-February2024.xlsx](https://seismic.sharepoint.com/:x:/s/Security/Ee3k76jb9DVOmQBTOZ1IU-ABPnvsqHBymxv3DfG8XBKZwg?e=uYHnlb)






















